### PR TITLE
Resetting `GLOBAL_VAR` to the initial state

### DIFF
--- a/tests/test_event_emit.py
+++ b/tests/test_event_emit.py
@@ -18,6 +18,7 @@ def subscription():
 def test_event_emit():
     """ Tests that a function subscribed to an event executes on emit. """
 
+    global GLOBAL_VAR
     # Before Emit
     assert GLOBAL_VAR == 'Init'
 
@@ -25,3 +26,4 @@ def test_event_emit():
 
     # After Emit
     assert GLOBAL_VAR == 'Finished'
+    GLOBAL_VAR = 'Init'


### PR DESCRIPTION
This PR aims to improve test reliability of `test_event_emit` by resetting `GLOBAL_VAR` to the `Init` state.

The test would fail in the following way if `GLOBAL_VAR` is not reset to `Init`:
```
>       assert GLOBAL_VAR == 'Init'
E       AssertionError: assert 'Finished' == 'Init'

test_event_emit.py:31: AssertionError
```