### PR TITLE
Resetting `bus` to the initial state

### DIFF
--- a/tests/test_subscribed_removal.py
+++ b/tests/test_subscribed_removal.py
@@ -25,6 +25,7 @@ def test_suscribed_event_was_removed():
 
     assert before_count == 1
     assert after_count == 0
+    bus.add_event(event=EVENT_NAME, func=event_one)
 
 
 def test_removing_event_that_doest_exist():


### PR DESCRIPTION
This PR aims to improve test reliability of test `test_suscribed_event_was_removed` by resetting `bus` to the initial state by calling `EventBus.add_event`

The test can fail in this way by running `pip3 install pytest-repeat; python3 -m pytest --count=2 tests/test_subscribed_removal.py::test_suscribed_event_was_removed`:

```
        if self._events[event] == event_funcs_copy:
            err_msg = "function doesn't exist inside event {} ".format(event)
>           raise EventDoesntExist(err_msg)
E           event_bus.exceptions.EventDoesntExist: function doesn't exist inside event event
```

It may be better to clean state pollutions so that some other tests won't fail in the future due to the shared state pollution.
